### PR TITLE
fix: derive MCP server version from package metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import dotenv from "dotenv";
 import minimist from "minimist";
 import { z } from "zod";
+import packageJson from "../package.json";
 
 // Import tools
 import { aggregateLogs } from "./tools/aggregateLogs.js";
@@ -79,7 +80,7 @@ aggregateLogs.initialize();
 // Set up MCP server
 const server = new McpServer({
   name: "datadog",
-  version: "1.0.0",
+  version: packageJson.version,
   description:
     "MCP Server for Datadog API, enabling interaction with Datadog resources"
 });


### PR DESCRIPTION
## Summary
- Read the MCP server version from package metadata instead of a hardcoded `1.0.0` literal.
- Keeps the server initialization version aligned with the package version on future releases.

Closes #12

## Validation
- `npm run build`
- `npm pack --dry-run --json`
- `node -e "const fs=require('fs'); const pkg=require('./package.json'); const js=fs.readFileSync('./dist/index.js','utf8'); if(!js.includes('package_json_1.default.version')) process.exit(1); console.log(JSON.stringify({packageVersion:pkg.version, usesPackageVersion: true}))"`
- `git diff --check`